### PR TITLE
Policy Error Fix

### DIFF
--- a/notificon.js
+++ b/notificon.js
@@ -82,7 +82,7 @@ or implied, of Matt Williams.
   };
 
   var getExistingFavicon = function getExistingFavicon() {
-    var favicon = findFaviconTag();
+    var favicon = findFaviconTag(false);
     return favicon ? favicon.getAttribute('href') : '/favicon.ico';
   };
 
@@ -137,6 +137,8 @@ or implied, of Matt Williams.
       return false;
     }
 
+    removeNotificon();
+
     var options = mergeDefaultOptions(myOptions);
 
     label = "" + label;
@@ -157,15 +159,15 @@ or implied, of Matt Williams.
       } catch(e) {
         if (console) {
           console.log('Notificon: cannot use icons located on a different domain (' + favicon + ')');
-          return false;
         }
+        return false;
       }
     };
     img.onerror = function() {
       if (console) {
         console.log('Notificon: image not found (' + options.favicon + ')');
-        return false;
       }
+      return false;
     };
     return true;
   };


### PR DESCRIPTION
Fixed a policy error which is caused by the findFaviconTag function. The said function fetches the favicon generated by the notificon instead of the original favicon.

I also moved the return false (inside the condition of console) since the return should not be based on the availability of console.
